### PR TITLE
Ingest RelativeCI bundle stats and build information during workflow_run

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -1,0 +1,20 @@
+name: RelativeCI
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types:
+      - completed
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: hmarr/debug-action@v3
+
+      - name: Send bundle stats and build information to RelativeCI
+        uses: relative-ci/agent-action@v2.2.0
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,13 +96,11 @@ jobs:
       - run: npm run build:bundle
         env:
           RELATIVE_CI_STATS: true
-      - name: Send build stats to RelativeCI
+      - name: Upload webpack stats artifact
         if: matrix.os == 'ubuntu-latest'
-        uses: relative-ci/agent-action@v2
+        uses: relative-ci/agent-upload-artifact-action@v2
         with:
-          token: ${{ github.token }}
           webpackStatsFile: ./distribution/assets/webpack-stats.json
-          key: ${{ secrets.RELATIVE_CI_KEY }}
       - uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:


### PR DESCRIPTION
https://relative-ci.com/documentation/setup/agent/github-action/#workflow_run-event

<!--

Thanks for contributing! 🍄 Do not ignore this, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

If you haven't done so yet, check out the Contributing page in the wiki: https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines

-->



## Test URLs


## Screenshot
