### PR TITLE
Ingest RelativeCI bundle stats and build information during workflow_run

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -7,12 +7,9 @@ on:
       - completed
 
 jobs:
-  on-success:
+  ingest:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: hmarr/debug-action@v3
-
       - name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2.2.0
         with:


### PR DESCRIPTION
https://relative-ci.com/documentation/setup/agent/github-action/#workflow_run-event

<!--

Thanks for contributing! 🍄 Do not ignore this, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

If you haven't done so yet, check out the Contributing page in the wiki: https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines

-->



## Test URLs


## Screenshot
